### PR TITLE
fix: bring back role meta

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,27 @@
+---
+allow_duplicates: true
+
+galaxy_info:
+  author: Robin Clarke, Jakob Reiter, Dale McDiarmid
+  description: Elasticsearch for Linux
+  company: "Elastic.co"
+  license: "license (Apache)"
+  min_ansible_version: 2.5.0
+  platforms:
+    - name: EL
+      versions:
+        - "6"
+        - "7"
+    - name: Debian
+      versions:
+        - all
+    - name: Ubuntu
+      versions:
+        - all
+    - galaxy_tags:
+        - elastic
+        - elasticsearch
+        - elk
+        - logging
+
+dependencies: []


### PR DESCRIPTION
Does not work with collections even with the direct install from git, leaving meta the same as previously as we are not planning on sharing this to the galaxy