### PR TITLE
fix: Remove lldp support

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,8 +424,6 @@ In addition to es_config, the following parameters allow the customization of th
 - `es_use_repository` Setting this to `false` will stop Ansible from using the official Elastic package from any repository configured on the system.
 - `es_add_repository` Setting this to `false` will stop Ansible to add the official Elastic package repositories (if es_use_repository is true) if you want to use a repo already present.
 - `es_custom_package_url` the URL to the rpm or deb package for Ansible to install. When using this you will also need to set `es_use_repository: false` and make sure that the `es_version` matches the version being installed from your custom URL. E.g. `es_custom_package_url: https://downloads.example.com/elasticsearch.rpm`
-- `es_identifier_string` String to search for LLDP neighbors to be used as value for `es_identifier_attribute`.
-- `es_identifier_attribute` Node attribute name declared in elasticsearch.yml as `node.attr.<name>`.
 
 Earlier examples illustrate the installation of plugins using `es_plugins`. For officially supported plugins no version or source delimiter is required. The plugin script will determine the appropriate plugin version based on the target Elasticsearch version. For community based plugins include the full url. This approach should NOT be used for the X-Pack plugin. See X-Pack below for details here.
 

--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -2,15 +2,6 @@
 {% if es_config %}
 {{ es_config | to_nice_yaml(indent=2) }}
 {% endif %}
-{% if ansible_local.lldp is defined %}
-{% for interface in ansible_local.lldp.lldp.interface %}
-{% set iface_data = interface.get(ansible_default_ipv4.interface) %}
-{% set chassis_key = iface_data.chassis.keys() | list | first %}
-{% if es_identifier_string in chassis_key %}
-node.attr.{{ es_identifier_attribute }}: {{ chassis_key }}
-{% endif %}
-{% endfor %}
-{% endif %}
 
 {% if es_config['cluster.name'] is not defined %}
 cluster.name: elasticsearch


### PR DESCRIPTION
we decided to move away from using lldp as node identifier