### PR TITLE
fix: resolve boolean conditional error for es_apt_key in Debian task

### DIFF
--- a/tasks/elasticsearch-Debian.yml
+++ b/tasks/elasticsearch-Debian.yml
@@ -51,7 +51,9 @@
       url: '{{ es_apt_key }}'
       id: '{{ es_apt_key_id }}'
       state: present
-    when: es_add_repository and es_apt_key | string
+    when:
+      - es_add_repository | bool
+      - es_apt_key | length > 0
 
   - name: Debian - Add elasticsearch repository
     apt_repository:


### PR DESCRIPTION
Ansible 2.17+ enforces strict boolean evaluation in `when` conditionals. The previous condition `es_apt_key | string` returns a string (the URL value), which causes the following error:

> Conditional result (True) was derived from value of type 'str'.
> Conditionals must have a boolean result.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved robustness of repository configuration validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->